### PR TITLE
Disabling windowStyle check as it isn't reliable

### DIFF
--- a/lib/amd-wrap-legacy.js
+++ b/lib/amd-wrap-legacy.js
@@ -2,15 +2,8 @@
 
 var RE = {
     alreadyWrapped: /^[\s]*define\s*\(/m,
-    windowStyle: /^[;\s]*\(\s*function *\(/m,
     disabled: /^\/[\/\*]+ *amd-wrap:disable/,
 };
-
-RE.alreadyAmd = new RegExp(
-    RE.alreadyWrapped.source + "|" +
-    RE.windowStyle.source,
-    "m"
-);
 
 module.exports = function (sourceText) {
     var shouldWrap = true;
@@ -20,7 +13,7 @@ module.exports = function (sourceText) {
         shouldWrap = false;
     } else {
         // see if is already an AMD
-        if (RE.alreadyAmd.test(sourceText))
+        if (RE.alreadyWrapped.test(sourceText))
             shouldWrap = false;
     }
 


### PR DESCRIPTION
@eleith i was having a problem where this `windowStyle` check would return "true" when there were arbitrary closures like `(function() {}` in the code, which was a problem because Babel outputs these closures sometimes.

i'm disabling it here because the only file i could find that followed the window style import but wouldn't get caught by the check for `define` was `jquery-ui`, which is an orphaned file anyway.

/cc @turadg in case you think this is worth going upstream to your fork - i needed a way to configure amdWrap to not care about these function closures. either worth adding a configuration value for the different flags, or a stronger check for the windowStyle imports (possibly checking if the function closure exists without a `define` call)
